### PR TITLE
refactor: make layers and label non-optional constants

### DIFF
--- a/Example/Framework/Classes/CPLoadingView.swift
+++ b/Example/Framework/Classes/CPLoadingView.swift
@@ -78,9 +78,9 @@ public class CPLoadingView : UIView {
         }
     }
     
-    private let progressLayer: CAShapeLayer! = CAShapeLayer()
-    private let shapeLayer: CAShapeLayer! = CAShapeLayer()
-    private let progressLabel: UILabel! = UILabel()
+    private let progressLayer: CAShapeLayer = CAShapeLayer()
+    private let shapeLayer: CAShapeLayer = CAShapeLayer()
+    private let progressLabel: UILabel = UILabel()
     
     private var completionBlock: CompletionBlock?
     


### PR DESCRIPTION
## Summary
- Avoid implicitly unwrapped optionals in CPLoadingView by using non-optional constants for progressLayer, shapeLayer, and progressLabel

## Testing
- `swift build` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_e_689e03652fa883339199f9286cb1a8a8