### PR TITLE
Refactor completion callbacks using optional chaining

### DIFF
--- a/Example/Framework/Classes/CPLoadingView.swift
+++ b/Example/Framework/Classes/CPLoadingView.swift
@@ -394,10 +394,8 @@ private extension CPLoadingView {
     @objc func hiddenLoadingView() {
         status = .completion
         isHidden = true
-        
-        if completionBlock != nil {
-            completionBlock!()
-        }
+
+        completionBlock?()
     }
 }
 
@@ -408,9 +406,7 @@ extension CPLoadingView: CAAnimationDelegate {
             Timer.scheduledTimer(timeInterval: kCPHidesWhenCompletedDelay, target: self, selector: #selector(CPLoadingView.hiddenLoadingView), userInfo: nil, repeats: false)
         } else {
             status = .completion
-            if completionBlock != nil {
-                completionBlock!()
-            }
+            completionBlock?()
         }
     }
 }


### PR DESCRIPTION
## Summary
- Simplify completion callback invocation by using optional chaining instead of explicit nil checks

## Testing
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*


------
https://chatgpt.com/codex/tasks/task_e_689e04491ca883338b2d68f1b52602ca