### PR TITLE
Replace selector-based timer with block in CPLoadingView

### DIFF
--- a/Example/Framework/Classes/CPLoadingView.swift
+++ b/Example/Framework/Classes/CPLoadingView.swift
@@ -390,7 +390,7 @@ private extension CPLoadingView {
         }
     }
     
-    @objc func hiddenLoadingView() {
+    private func hiddenLoadingView() {
         status = .completion
         isHidden = true
 
@@ -402,7 +402,9 @@ private extension CPLoadingView {
 extension CPLoadingView: CAAnimationDelegate {
     public func animationDidStop(_ anim: CAAnimation, finished flag: Bool) {
         if hidesWhenCompleted {
-            Timer.scheduledTimer(timeInterval: hidesAfterTime, target: self, selector: #selector(CPLoadingView.hiddenLoadingView), userInfo: nil, repeats: false)
+            Timer.scheduledTimer(withTimeInterval: hidesAfterTime, repeats: false) { [weak self] _ in
+                self?.hiddenLoadingView()
+            }
         } else {
             status = .completion
             completionBlock?()


### PR DESCRIPTION
## Summary
- use a block-based timer to hide `CPLoadingView`
- make `hiddenLoadingView` a private helper

## Testing
- `swiftc Example/Framework/Classes/CPLoadingView.swift` *(fails: no such module 'UIKit')*

------
https://chatgpt.com/codex/tasks/task_e_689e05c2dfd4833393d9da417524c3fc