### PR TITLE
Use guard let for sender type casts

### DIFF
--- a/Example/CPLoading/ViewController.swift
+++ b/Example/CPLoading/ViewController.swift
@@ -39,13 +39,19 @@ class ViewController: UIViewController {
     }
     
     @IBAction func switchValueChanged(_ sender: AnyObject) {
-        let switchCtr = sender as! UISwitch
+        guard let switchCtr = sender as? UISwitch else {
+            // Unable to cast sender to UISwitch
+            return
+        }
         loadingView.hidesWhenCompleted = switchCtr.isOn
     }
     
     @IBAction func changeLineWith(_ sender: AnyObject) {
         if loadingView.status == .loading {
-            let slider = sender as! UISlider
+            guard let slider = sender as? UISlider else {
+                // Unable to cast sender to UISlider
+                return
+            }
             loadingView.lineWidth = CGFloat(slider.value)
         } else {
             self.slider.value = Float(loadingView.lineWidth)


### PR DESCRIPTION
## Summary
- Ensure `switchValueChanged` only handles valid `UISwitch` instances.
- Guard the `changeLineWith` slider cast to safely update line width.

## Testing
- `swift build` *(fails: Could not find Package.swift)*
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_689e078ababc8333a7d5cc580b5d2b0f